### PR TITLE
add a configurable custom domain Update scanner.py

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -1,6 +1,8 @@
 name: Publish Server Docker Image
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - main

--- a/ha-addon/server/scanner.py
+++ b/ha-addon/server/scanner.py
@@ -1698,7 +1698,8 @@ def get_device_address(config: dict, device_name: str) -> tuple[str, str]:
     The source is exposed in the UI so users can see how each device's IP
     was resolved (#184).
     """
-    fallback = (f"{device_name}.local", "mdns_default")
+    wifi_domain = (config.get("wifi") or config.get("ethernet") or {}).get("domain", ".local")
+    fallback = (f"{device_name}{wifi_domain}", "mdns_default")
 
     if not isinstance(config, dict):
         return fallback


### PR DESCRIPTION
add a configurable custom domain instead of always using .local
For example, many users run their ESPHome devices under domains such as .iot, .lan, or other local DNS zones. Currently Fleet appears to search for devices only in the .local domain, which prevents discovery in these setups.