### PR TITLE
fix(registry): disk-full health block false-positives on large volumes

### DIFF
--- a/ha-addon/client/protocol.py
+++ b/ha-addon/client/protocol.py
@@ -79,6 +79,15 @@ class SystemInfo(_ProtocolMessage):
     disk_total: Optional[str] = None
     disk_free: Optional[str] = None
     disk_used_pct: Optional[int] = None
+    # Raw free-space byte count backing disk_free/disk_used_pct. Needed
+    # because a percentage alone is meaningless without knowing the disk's
+    # absolute scale — see registry.Worker.evaluate_health's absolute-floor
+    # check (bug: a many-TB worker volume at >=95% used still has huge
+    # absolute headroom, but a pure-percentage gate falsely blocks it).
+    # Optional/additive: an older worker that hasn't upgraded simply omits
+    # it, and evaluate_health falls back to pure percentage-based blocking
+    # (pre-fix behavior).
+    disk_free_bytes: Optional[int] = None
     # DQ.6: worker's view of the disk-quota engine's most recent state.
     # ``disk_usage_bytes`` is the engine's measured byte total under
     # ``/esphome-versions/`` (venvs + caches + slots + pio-slots).

--- a/ha-addon/client/sysinfo.py
+++ b/ha-addon/client/sysinfo.py
@@ -202,11 +202,13 @@ def collect_system_info(versions_dir: str = "/esphome-versions") -> dict:
     disk_total: Optional[str] = None
     disk_free: Optional[str] = None
     disk_pct: Optional[int] = None
+    disk_free_bytes: Optional[int] = None
     try:
         du = psutil.disk_usage(versions_dir)
         disk_total = _format_memory(du.total)
         disk_free = _format_memory(du.free)
         disk_pct = round(du.percent)
+        disk_free_bytes = du.free
     except Exception:
         pass
 
@@ -251,6 +253,7 @@ def collect_system_info(versions_dir: str = "/esphome-versions") -> dict:
         "disk_total": disk_total,
         "disk_free": disk_free,
         "disk_used_pct": disk_pct,
+        "disk_free_bytes": disk_free_bytes,
         "cached_targets": cached_targets,
         "cache_size_mb": cache_size_mb,
     }

--- a/ha-addon/server/constants.py
+++ b/ha-addon/server/constants.py
@@ -44,3 +44,18 @@ MIN_ESPHOME_VERSION = "2026.4.0"
 # (~1 GiB) on a 50 GiB worker rootfs without false trips.
 WORKER_DISK_BLOCK_ENTER_PCT = 95
 WORKER_DISK_BLOCK_EXIT_PCT = 90
+
+# Absolute-space floor for the disk-pressure gate above (bug: a worker with
+# a many-TB volume at >=95% used still has enormous headroom in absolute
+# terms — e.g. 25.8 TB at 95% used leaves ~1.2 TB free, but a compile job
+# only needs ~1.6 GB: ~600 MB PlatformIO toolchain extract + ~1 GiB ESPHome
+# venv install. Blocking purely on percentage falsely starves huge volumes
+# of work. The block now requires BOTH signals: percentage AND absolute
+# free space below this floor. 15 GiB gives ~9x the single-job footprint —
+# covers several concurrent build slots plus the fleet's own
+# default_worker_disk_quota_bytes (10 GiB, settings.py) headroom, with
+# margin for OS/logs/other containers sharing the host disk. On a typical
+# worker in the tens-of-GB range this floor is smaller than 5% of the
+# disk, so it's always satisfied whenever percentage crosses ENTER — i.e.
+# behavior on small/typical disks is unchanged from before this fix.
+WORKER_DISK_FREE_FLOOR_BYTES = 15 * 1024 ** 3

--- a/ha-addon/server/constants.py
+++ b/ha-addon/server/constants.py
@@ -55,7 +55,10 @@ WORKER_DISK_BLOCK_EXIT_PCT = 90
 # covers several concurrent build slots plus the fleet's own
 # default_worker_disk_quota_bytes (10 GiB, settings.py) headroom, with
 # margin for OS/logs/other containers sharing the host disk. On a typical
-# worker in the tens-of-GB range this floor is smaller than 5% of the
-# disk, so it's always satisfied whenever percentage crosses ENTER — i.e.
-# behavior on small/typical disks is unchanged from before this fix.
+# worker in the tens-of-GB range this floor is *larger* than the 5% left
+# free at the ENTER threshold (on a 50 GiB disk, 5% is 2.5 GiB — well
+# under 15 GiB), so the floor is always satisfied whenever percentage
+# crosses ENTER, i.e. behavior on small/typical disks is unchanged from
+# before this fix. The floor only starts gating above ~300 GiB, which is
+# exactly where a percentage-only rule stops being meaningful.
 WORKER_DISK_FREE_FLOOR_BYTES = 15 * 1024 ** 3

--- a/ha-addon/server/protocol.py
+++ b/ha-addon/server/protocol.py
@@ -79,6 +79,15 @@ class SystemInfo(_ProtocolMessage):
     disk_total: Optional[str] = None
     disk_free: Optional[str] = None
     disk_used_pct: Optional[int] = None
+    # Raw free-space byte count backing disk_free/disk_used_pct. Needed
+    # because a percentage alone is meaningless without knowing the disk's
+    # absolute scale — see registry.Worker.evaluate_health's absolute-floor
+    # check (bug: a many-TB worker volume at >=95% used still has huge
+    # absolute headroom, but a pure-percentage gate falsely blocks it).
+    # Optional/additive: an older worker that hasn't upgraded simply omits
+    # it, and evaluate_health falls back to pure percentage-based blocking
+    # (pre-fix behavior).
+    disk_free_bytes: Optional[int] = None
     # DQ.6: worker's view of the disk-quota engine's most recent state.
     # ``disk_usage_bytes`` is the engine's measured byte total under
     # ``/esphome-versions/`` (venvs + caches + slots + pio-slots).

--- a/ha-addon/server/registry.py
+++ b/ha-addon/server/registry.py
@@ -84,13 +84,28 @@ class Worker:
         }
 
     def evaluate_health(self) -> bool:
-        """Recompute ``health_blocked_reason`` from ``system_info`` (#219).
+        """Recompute ``health_blocked_reason`` from ``system_info`` (#219, + absolute-floor fix).
 
-        Hysteresis: enter blocked at ``WORKER_DISK_BLOCK_ENTER_PCT``; exit
-        only when usage drops to or below ``WORKER_DISK_BLOCK_EXIT_PCT``.
+        Enter blocked only when BOTH signals are bad: ``disk_used_pct`` at/above
+        ``WORKER_DISK_BLOCK_ENTER_PCT`` AND absolute free space below
+        ``WORKER_DISK_FREE_FLOOR_BYTES``. A many-TB volume that's "95% full" but
+        has 1+ TB free must NOT trip this — the app only ever needs ~1.6 GB.
+        Exit (clear) on EITHER signal recovering: usage drops to/below
+        ``WORKER_DISK_BLOCK_EXIT_PCT``, OR absolute free rises back above the
+        floor. Deliberately asymmetric (AND to enter, OR to exit) so the gate
+        stays conservative about newly blocking but quick to unblock.
+
+        Backward compatibility: if the worker hasn't upgraded to send
+        ``disk_free_bytes`` (or sends a non-numeric value), falls back to the
+        original pure-percentage hysteresis unchanged.
+
         Returns True iff the state transitioned (caller can broadcast).
         """
-        from constants import WORKER_DISK_BLOCK_ENTER_PCT, WORKER_DISK_BLOCK_EXIT_PCT  # noqa: PLC0415
+        from constants import (  # noqa: PLC0415
+            WORKER_DISK_BLOCK_ENTER_PCT,
+            WORKER_DISK_BLOCK_EXIT_PCT,
+            WORKER_DISK_FREE_FLOOR_BYTES,
+        )
         info = self.system_info or {}
         pct = info.get("disk_used_pct")
         if pct is None:
@@ -99,11 +114,30 @@ class Worker:
             pct_int = int(pct)
         except (TypeError, ValueError):
             return False
+
+        free_bytes_raw = info.get("disk_free_bytes")
+        free_bytes: Optional[int] = None
+        if free_bytes_raw is not None:
+            try:
+                free_bytes = int(free_bytes_raw)
+            except (TypeError, ValueError):
+                free_bytes = None
+
         previous = self.health_blocked_reason
-        if previous is None and pct_int >= WORKER_DISK_BLOCK_ENTER_PCT:
-            self.health_blocked_reason = "disk_full"
-        elif previous == "disk_full" and pct_int <= WORKER_DISK_BLOCK_EXIT_PCT:
-            self.health_blocked_reason = None
+
+        if free_bytes is None:
+            # Old worker / missing field: percentage-only, exactly as before.
+            if previous is None and pct_int >= WORKER_DISK_BLOCK_ENTER_PCT:
+                self.health_blocked_reason = "disk_full"
+            elif previous == "disk_full" and pct_int <= WORKER_DISK_BLOCK_EXIT_PCT:
+                self.health_blocked_reason = None
+        else:
+            low_absolute_free = free_bytes < WORKER_DISK_FREE_FLOOR_BYTES
+            if previous is None and pct_int >= WORKER_DISK_BLOCK_ENTER_PCT and low_absolute_free:
+                self.health_blocked_reason = "disk_full"
+            elif previous == "disk_full" and (pct_int <= WORKER_DISK_BLOCK_EXIT_PCT or not low_absolute_free):
+                self.health_blocked_reason = None
+
         return self.health_blocked_reason != previous
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -166,6 +166,17 @@ class TestRoundTrip:
         assert msg.disk_quota_bytes is None
         assert msg.last_eviction_freed_bytes is None
 
+    def test_system_info_disk_free_bytes_roundtrip(self) -> None:
+        """Absolute-floor fix: raw free-space bytes backing disk_used_pct."""
+        msg = SystemInfo(disk_free_bytes=1176 * 1024 ** 3)
+        d = msg.model_dump()
+        assert d["disk_free_bytes"] == 1176 * 1024 ** 3
+        assert SystemInfo.model_validate(d) == msg
+
+    def test_system_info_disk_free_bytes_default_none(self) -> None:
+        msg = SystemInfo()
+        assert msg.disk_free_bytes is None
+
     def test_heartbeat_response_stream_logs_omitted_is_none(self) -> None:
         # No flag = no change from the worker's current state. Default must
         # be None so we can distinguish "unchanged" from "stop".

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -251,3 +251,102 @@ def test_heartbeat_without_disk_used_pct_does_not_clear_block(reg):
     assert reg.get(client_id).health_blocked_reason == "disk_full"
     reg.heartbeat(client_id, system_info={"cpu_usage": 5})  # no disk_used_pct
     assert reg.get(client_id).health_blocked_reason == "disk_full"
+
+
+# ---------------------------------------------------------------------------
+# Absolute-free-space floor (bug: a many-TB worker volume at >=95% used still
+# has huge absolute headroom — a pure-percentage gate falsely blocks it).
+# ---------------------------------------------------------------------------
+
+_GIB = 1024 ** 3
+
+
+def test_heartbeat_huge_disk_high_pct_high_absolute_free_not_blocked(reg):
+    """The bug's exact repro: 25.8 TB disk at 96% used still has ~1176 GB
+    free — must NOT block despite crossing the percentage threshold."""
+    client_id = reg.register("host1", "linux/amd64")
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 96, "disk_free_bytes": 1176 * _GIB},
+    )
+    assert reg.get(client_id).health_blocked_reason is None
+
+
+def test_heartbeat_small_disk_high_pct_low_absolute_free_still_blocked(reg):
+    """Regression guard: a small disk at high percentage with genuinely low
+    absolute free space must still block, exactly as before this fix."""
+    client_id = reg.register("host1", "linux/amd64")
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 96, "disk_free_bytes": 2 * _GIB},
+    )
+    assert reg.get(client_id).health_blocked_reason == "disk_full"
+
+
+def test_heartbeat_combined_exit_via_absolute_free_while_in_hysteresis_band(reg):
+    """Percentage alone (93%, inside the 90-95 hysteresis band) would not
+    clear a block — but absolute free space recovering above the floor
+    clears it via the OR-to-exit path."""
+    client_id = reg.register("host1", "linux/amd64")
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 96, "disk_free_bytes": 2 * _GIB},
+    )
+    assert reg.get(client_id).health_blocked_reason == "disk_full"
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 93, "disk_free_bytes": 20 * _GIB},
+    )
+    assert reg.get(client_id).health_blocked_reason is None
+
+
+def test_heartbeat_combined_stays_blocked_in_hysteresis_band_when_free_still_low(reg):
+    """Complement of the above: inside the hysteresis band AND absolute
+    free space still below the floor — neither exit condition is met, so
+    it must stay blocked."""
+    client_id = reg.register("host1", "linux/amd64")
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 96, "disk_free_bytes": 2 * _GIB},
+    )
+    assert reg.get(client_id).health_blocked_reason == "disk_full"
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 93, "disk_free_bytes": 2 * _GIB},
+    )
+    assert reg.get(client_id).health_blocked_reason == "disk_full"
+
+
+def test_heartbeat_huge_disk_never_blocks_across_pct_oscillation(reg):
+    """A huge disk oscillating between 94% and 97% used, with absolute free
+    space always far above the floor, must never transition to blocked."""
+    client_id = reg.register("host1", "linux/amd64")
+    for pct in (94, 97, 95, 94, 97):
+        reg.heartbeat(
+            client_id,
+            system_info={"disk_used_pct": pct, "disk_free_bytes": 1176 * _GIB},
+        )
+        assert reg.get(client_id).health_blocked_reason is None
+
+
+def test_heartbeat_disk_free_bytes_absent_matches_legacy_percentage_only_behavior(reg):
+    """An old worker that hasn't upgraded to send disk_free_bytes gets the
+    exact pre-fix percentage-only hysteresis."""
+    client_id = reg.register("host1", "linux/amd64")
+    reg.heartbeat(client_id, system_info={"disk_used_pct": 96})
+    assert reg.get(client_id).health_blocked_reason == "disk_full"
+    reg.heartbeat(client_id, system_info={"disk_used_pct": 92})
+    assert reg.get(client_id).health_blocked_reason == "disk_full"  # hysteresis band
+    reg.heartbeat(client_id, system_info={"disk_used_pct": 89})
+    assert reg.get(client_id).health_blocked_reason is None
+
+
+def test_heartbeat_disk_free_bytes_non_numeric_falls_back_to_percentage_only(reg):
+    """A garbage disk_free_bytes value is treated as absent, not as a crash
+    or a silent "always low" — falls back to legacy percentage-only."""
+    client_id = reg.register("host1", "linux/amd64")
+    reg.heartbeat(
+        client_id,
+        system_info={"disk_used_pct": 96, "disk_free_bytes": "not-a-number"},
+    )
+    assert reg.get(client_id).health_blocked_reason == "disk_full"


### PR DESCRIPTION
## Summary

A worker with a many-TB disk volume at >=95% used gets permanently marked `health_blocked_reason=disk_full` and refused all jobs — even with enormous absolute free space (e.g. 25.8 TB at 95% used still leaves ~1.2 TB free, but a compile job only needs ~1.6 GB: ~600 MB PlatformIO toolchain extract + ~1 GiB ESPHome venv install).

Root cause: the health-block gate (`Worker.evaluate_health()` in `registry.py`, thresholds in `constants.py`) is purely percentage-based. The threshold comment admits it was sized for "a typical ... 50 GiB worker rootfs" — an assumption that breaks down completely at TB scale, where 5% headroom is over a terabyte.

Found and verified against a real production worker (25.8 TB volume, 92-96% used) that was permanently stuck refusing jobs under the old logic, and confirmed working (claiming and completing jobs) after this fix.

## Fix

The block now requires **both** signals bad to enter (percentage AND absolute free space below a new `WORKER_DISK_FREE_FLOOR_BYTES` floor, 15 GiB), and clears on **either** recovering (percentage OR absolute free). A new optional `disk_free_bytes` field on `SystemInfo` (both protocol.py copies, additive, no `PROTOCOL_VERSION` bump) carries the raw byte count needed for the absolute check.

Workers that haven't upgraded (field absent) fall back to the exact pre-fix percentage-only behavior — every existing test in `test_registry.py` passes unmodified, since none of them set `disk_free_bytes`.

## Test plan

- [x] `pytest tests/test_registry.py tests/test_protocol.py` — 9 new tests covering: the bug's exact repro (huge disk, high %, not blocked), regression guard (small disk, high %, still blocked), hysteresis-band interaction via the absolute-free OR-exit path, oscillation safety on huge disks, and backward compat (field absent / non-numeric).
- [x] Full suite, `ruff`, `mypy`, `check-invariants.sh` (PY-6 protocol identity) all green.
- [x] Verified live against production: worker previously stuck at `health_blocked_reason=disk_full` (92-96% used, ~1.9 TB free) now shows `health_blocked_reason: null` and is actively claiming/completing jobs.

Generated with [Claude Code](https://claude.com/claude-code)