### PR TITLE
fix: worker build-artifact detection, venv self-heal, and validator lock contention

### DIFF
--- a/ha-addon/client/client.py
+++ b/ha-addon/client/client.py
@@ -2355,20 +2355,26 @@ def _collect_firmware_variants(build_dir: str, target_stem: str) -> dict[str, Pa
       {build_dir}/.esphome/build/{device_name}/.pioenvs/{device_name}/firmware.bin
 
       {build_dir}/.esphome/build/{device_name}/build/firmware.factory.bin                   (native ESP-IDF — ESP32 since ESPHome 2026.7)
-      {build_dir}/.esphome/build/{device_name}/build/firmware.bin
+      {build_dir}/.esphome/build/{device_name}/build/firmware.bin      or  firmware.ota.bin
 
     ESPHome 2026.7 replaced PlatformIO with a native ESP-IDF installer
     for ESP32 targets; that toolchain drops the
     ``.pioenvs/{device_name}/`` staging directory entirely and writes
     binaries straight into ``build/``. Both shapes are checked so
     Arduino/LibreTiny targets (still PlatformIO) and ESP-IDF-native
-    ESP32 targets both resolve.
+    ESP32 targets both resolve. Within the native-ESP-IDF shape, the
+    OTA-safe filename itself has moved at least once — observed as
+    ``firmware.bin`` and, as of ESPHome 2026.7's esp32c6 native build,
+    ``firmware.ota.bin`` (both created alongside ``firmware.factory.bin``
+    and ``firmware.elf``) — so both are checked and either one satisfies
+    the ``ota`` variant.
 
     Returns a mapping of ``variant → path``:
       - ``factory``: full flash image (ESP32 only; used for first
         USB/serial flash).
-      - ``ota``: the ``firmware.bin`` shape (smaller, OTA-safe; ESP32
-        produces this alongside factory; ESP8266 produces only this).
+      - ``ota``: the smaller, OTA-safe shape — ``firmware.bin`` or
+        ``firmware.ota.bin`` depending on toolchain version; ESP32
+        produces this alongside factory, ESP8266 produces only this.
 
     The device name can differ from the target filename stem if the
     YAML uses substitutions, so we walk every device_dir under
@@ -2393,22 +2399,33 @@ def _collect_firmware_variants(build_dir: str, target_stem: str) -> dict[str, Pa
             device_dir / "build",                        # native ESP-IDF layout
         ]
         for root in candidate_roots:
+            # "ota" has two possible filenames: PlatformIO and older
+            # ESP-IDF-native builds emit firmware.bin; ESPHome's ESP32
+            # native-ESP-IDF toolchain (2026.7+) renamed it to
+            # firmware.ota.bin. Check both so neither toolchain silently
+            # loses its OTA-safe variant (bug: pool-pump build produced
+            # only firmware.ota.bin, so the old firmware.bin-only check
+            # found nothing, archived just "factory", and server-side OTA
+            # failed before it could even ping the device).
             candidates = {
-                "factory": root / "firmware.factory.bin",
-                "ota": root / "firmware.bin",
+                "factory": [root / "firmware.factory.bin"],
+                "ota": [root / "firmware.bin", root / "firmware.ota.bin"],
             }
-            for variant_name, path in candidates.items():
-                if not path.is_file():
-                    continue
+            for variant_name, paths in candidates.items():
                 # First-match wins when multiple device_dirs/roots exist
                 # (usually there's only one; substitutions don't spawn
                 # duplicates).
-                if variant_name not in variants:
+                if variant_name in variants:
+                    continue
+                for path in paths:
+                    if not path.is_file():
+                        continue
                     variants[variant_name] = path
                     logger.info(
                         "Located firmware variant %s for %s: %s (%d bytes)",
                         variant_name, target_stem, path, path.stat().st_size,
                     )
+                    break
 
     if not variants:
         logger.warning(

--- a/ha-addon/client/version_manager.py
+++ b/ha-addon/client/version_manager.py
@@ -218,7 +218,13 @@ class VersionManager:
                 capture_output=True,
                 text=True,
             )
-        except Exception:
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            stdout = (exc.stdout or "").strip()
+            logger.error(
+                "python -m venv failed (exit %d):\nstderr: %s\nstdout: %s",
+                exc.returncode, stderr, stdout,
+            )
             shutil.rmtree(str(venv_dir), ignore_errors=True)
             raise
 

--- a/ha-addon/client/version_manager.py
+++ b/ha-addon/client/version_manager.py
@@ -202,15 +202,34 @@ class VersionManager:
         venv_dir = self._venv_path(version)
         logger.info("Installing esphome==%s into %s", version, venv_dir)
 
-        # Create venv
-        subprocess.run(
-            [sys.executable, "-m", "venv", str(venv_dir)],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        # Wipe any stale/partial venv from a previous failed attempt so we
+        # start clean (otherwise a venv missing bin/pip causes FileNotFoundError
+        # on every subsequent restart until /data is cleared).
+        if venv_dir.exists():
+            logger.info("Removing stale venv at %s before reinstall", venv_dir)
+            shutil.rmtree(str(venv_dir), ignore_errors=True)
+
+        venv_cmd = [sys.executable, "-m", "venv", str(venv_dir)]
+        logger.info("Running: %s", " ".join(venv_cmd))
+        try:
+            subprocess.run(
+                venv_cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            shutil.rmtree(str(venv_dir), ignore_errors=True)
+            raise
 
         pip = venv_dir / "bin" / "pip"
+        if not pip.exists():
+            shutil.rmtree(str(venv_dir), ignore_errors=True)
+            raise RuntimeError(
+                f"venv created at {venv_dir} but bin/pip is missing — "
+                "ensurepip may be unavailable in this Python installation"
+            )
+
         install_cmd: list[str] = [
             str(pip), "install", "--no-cache-dir", f"esphome=={version}",
         ]

--- a/ha-addon/server/scanner.py
+++ b/ha-addon/server/scanner.py
@@ -1220,6 +1220,18 @@ def _resolve_esphome_config(config_dir: str, target: str) -> Optional[dict]:
 
         # Stage 1 — full validation. Catches domain-aware addressing and
         # every other schema-level field ESPHome injects.
+        #
+        # Non-blocking lock check: _full_validate_config acquires
+        # _validator_lock which can be held for 60-120 s when resolving
+        # configs with external git components. If this function is called
+        # from the event loop thread (e.g. /ui/api/targets 1-Hz poll),
+        # blocking here freezes the entire server. Return None immediately
+        # if the lock is busy — the caller falls back to raw YAML metadata
+        # and the cache will be populated by the background executor task
+        # (build_name_to_target_map / reseed_device_poller_from_config).
+        if not _validator_lock.acquire(blocking=False):
+            return None
+        _validator_lock.release()
         try:
             config = _full_validate_config(path)
             _config_cache[target] = (mtime, config)

--- a/ha-addon/server/scanner.py
+++ b/ha-addon/server/scanner.py
@@ -1136,7 +1136,8 @@ def _full_validate_config(path: Path) -> dict:
     typos elsewhere in the file). Returns the validated config dict on
     success.
 
-    Serialized via ``_validator_lock`` and prefixed with ``CORE.reset()``:
+    Caller must hold ``_validator_lock`` for the duration of this call
+    (see ``_resolve_esphome_config``) and prefix with ``CORE.reset()``:
     ESPHome's CORE is process-global and non-reentrant; without the
     lock, concurrent executor threads interleave CORE mutations and
     produce phantom "Duplicate entity" errors on targets that validate
@@ -1151,22 +1152,21 @@ def _full_validate_config(path: Path) -> dict:
     from esphome.yaml_util import load_yaml  # noqa: PLC0415
     from esphome.config import validate_config  # noqa: PLC0415
 
-    with _validator_lock:
-        CORE.reset()
-        CORE.config_path = path
-        config = load_yaml(path)
-        if not isinstance(config, dict):
-            raise ValueError(f"YAML root of {path.name} is not a mapping")
-        # skip_external_update=True reuses any previously-cloned external
-        # component sources; the first validation per external-components
-        # entry still clones. Same caching shape we've always used for
-        # do_packages_pass.
-        result = validate_config(config, None, skip_external_update=True)
-        if result.errors:
-            first = result.errors[0]
-            msg = getattr(first, "msg", None) or str(first)
-            raise RuntimeError(f"validation errors ({len(result.errors)} total): {msg}")
-        return result
+    CORE.reset()
+    CORE.config_path = path
+    config = load_yaml(path)
+    if not isinstance(config, dict):
+        raise ValueError(f"YAML root of {path.name} is not a mapping")
+    # skip_external_update=True reuses any previously-cloned external
+    # component sources; the first validation per external-components
+    # entry still clones. Same caching shape we've always used for
+    # do_packages_pass.
+    result = validate_config(config, None, skip_external_update=True)
+    if result.errors:
+        first = result.errors[0]
+        msg = getattr(first, "msg", None) or str(first)
+        raise RuntimeError(f"validation errors ({len(result.errors)} total): {msg}")
+    return result
 
 
 def _resolve_esphome_config(config_dir: str, target: str) -> Optional[dict]:
@@ -1221,29 +1221,40 @@ def _resolve_esphome_config(config_dir: str, target: str) -> Optional[dict]:
         # Stage 1 — full validation. Catches domain-aware addressing and
         # every other schema-level field ESPHome injects.
         #
-        # Non-blocking lock check: _full_validate_config acquires
-        # _validator_lock which can be held for 60-120 s when resolving
-        # configs with external git components. If this function is called
-        # from the event loop thread (e.g. /ui/api/targets 1-Hz poll),
-        # blocking here freezes the entire server. Return None immediately
-        # if the lock is busy — the caller falls back to raw YAML metadata
-        # and the cache will be populated by the background executor task
-        # (build_name_to_target_map / reseed_device_poller_from_config).
+        # Non-blocking lock: _full_validate_config can hold this lock for
+        # 60-120 s when resolving configs with external git components. If
+        # this function is called from the event loop thread (e.g.
+        # /ui/api/targets 1-Hz poll), blocking here freezes the entire
+        # server. Return None immediately if the lock is busy — the caller
+        # falls back to raw YAML metadata and the cache will be populated
+        # by the background executor task (build_name_to_target_map /
+        # reseed_device_poller_from_config).
+        #
+        # The acquire is held for the ENTIRE validation call, not just
+        # checked-then-released: releasing before calling
+        # _full_validate_config (which used to acquire the same lock
+        # itself, blockingly) left a race window where another thread
+        # could grab the lock in between, and this caller would then block
+        # on _full_validate_config's own acquire anyway — defeating the
+        # whole point of checking non-blocking first. Holding it here for
+        # the duration closes that window.
         if not _validator_lock.acquire(blocking=False):
             return None
-        _validator_lock.release()
         try:
-            config = _full_validate_config(path)
-            _config_cache[target] = (mtime, config)
-            return config
-        except Exception as exc:
-            logger.warning(
-                "Full validation of %s failed (%s: %s) — falling back to "
-                "substitution-only pass. UI metadata will still populate "
-                "but domain-aware OTA addressing will not.",
-                target, type(exc).__name__, exc,
-            )
-            logger.debug("Full validation traceback for %s:", target, exc_info=True)
+            try:
+                config = _full_validate_config(path)
+                _config_cache[target] = (mtime, config)
+                return config
+            except Exception as exc:
+                logger.warning(
+                    "Full validation of %s failed (%s: %s) — falling back to "
+                    "substitution-only pass. UI metadata will still populate "
+                    "but domain-aware OTA addressing will not.",
+                    target, type(exc).__name__, exc,
+                )
+                logger.debug("Full validation traceback for %s:", target, exc_info=True)
+        finally:
+            _validator_lock.release()
 
         # Stage 2 — substitution-only fallback (legacy path). Preserves
         # behavior for configs that don't fully validate so device

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1116,7 +1116,7 @@ def test_collect_firmware_variants_espidf_native_ota_bin_layout(tmp_path):
     was silently dropped — only factory got archived, and server-side
     OTA (_server_ota_push) failed before it could even ping the device
     since it requires an ota/firmware variant to exist in storage."""
-    import client as client_mod  # noqa: PLC0415
+    import client as client_mod  # noqa: PLC0415 — see section note above
 
     device_dir = tmp_path / ".esphome" / "build" / "testdevice" / "build"
     device_dir.mkdir(parents=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1109,6 +1109,27 @@ def test_collect_firmware_variants_espidf_native_layout(tmp_path):
     assert variants["ota"].read_bytes() == b"ota"
 
 
+def test_collect_firmware_variants_espidf_native_ota_bin_layout(tmp_path):
+    """Regression: ESPHome 2026.7's esp32c6 native ESP-IDF build emits
+    firmware.ota.bin instead of firmware.bin for the OTA-safe shape.
+    Before this fix, only firmware.bin was checked, so the ota variant
+    was silently dropped — only factory got archived, and server-side
+    OTA (_server_ota_push) failed before it could even ping the device
+    since it requires an ota/firmware variant to exist in storage."""
+    import client as client_mod  # noqa: PLC0415
+
+    device_dir = tmp_path / ".esphome" / "build" / "testdevice" / "build"
+    device_dir.mkdir(parents=True)
+    (device_dir / "firmware.factory.bin").write_bytes(b"factory")
+    (device_dir / "firmware.ota.bin").write_bytes(b"ota")
+
+    variants = client_mod._collect_firmware_variants(str(tmp_path), "testdevice")
+
+    assert variants.keys() == {"factory", "ota"}
+    assert variants["factory"].read_bytes() == b"factory"
+    assert variants["ota"].read_bytes() == b"ota"
+
+
 def test_collect_firmware_variants_missing_returns_empty(tmp_path, caplog):
     """Neither layout present: returns {} and logs a warning, doesn't raise."""
     import client as client_mod  # noqa: PLC0415 — see section note above

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1673,6 +1673,40 @@ def test_resolve_failure_logs_warning(tmp_path, caplog):
     )
 
 
+def test_resolve_esphome_config_holds_lock_for_entire_validation(tmp_path):
+    """Copilot review finding on PR #133: the non-blocking pre-check used to
+    acquire-then-immediately-release _validator_lock before calling
+    _full_validate_config, which itself acquired the same lock again,
+    blockingly. That left a race window where another thread could grab
+    the lock in between, and this caller would then block anyway --
+    defeating the whole point of checking non-blocking first. The lock
+    must now be held by the caller for the full duration of the call."""
+    from unittest.mock import patch
+    import scanner as scanner_module
+    from scanner import _resolve_esphome_config
+
+    good = tmp_path / "lock_duration_test_device.yaml"
+    good.write_text("esphome:\n  name: device\n")
+
+    lock_state_during_call = {}
+
+    def _fake_full_validate_config(path):
+        lock_state_during_call["locked"] = scanner_module._validator_lock.locked()
+        return {"esphome": {"name": "device"}}
+
+    with patch("scanner._full_validate_config", new=_fake_full_validate_config):
+        result = _resolve_esphome_config(str(tmp_path), "lock_duration_test_device.yaml")
+
+    assert result == {"esphome": {"name": "device"}}
+    assert lock_state_during_call["locked"] is True, (
+        "the lock must be held for the duration of _full_validate_config, "
+        "not released before calling it"
+    )
+    assert not scanner_module._validator_lock.locked(), (
+        "the lock must be released again once validation completes"
+    )
+
+
 # --- Bug #112 — bundle subprocess stderr is clean (no esphome logger noise) -
 
 def test_bundle_subprocess_stderr_does_not_leak_esphome_logger_chatter():


### PR DESCRIPTION
Four independent fixes, split out of #133 so they can land without waiting on the server-side-OTA feature. No shared code between them beyond living in the worker/scanner; each commit stands alone.

### `firmware.ota.bin` is a valid OTA artifact

ESPHome's native ESP-IDF toolchain (2026.7+, ESP32) emits the OTA-safe image as `firmware.ota.bin` alongside `firmware.factory.bin`, where the PlatformIO layout emitted `firmware.bin`. `_collect_firmware_variants` only knew the old name, so on those builds it found no `ota` variant, archived `factory` only, and any consumer expecting an OTA-safe image got nothing. Both names are now accepted for the `ota` variant.

### Stale/partial venv now self-heals

If `python -m venv` or the subsequent `pip install` died partway (disk full, container killed), the leftover directory had `bin/esphome` absent but the directory present. Every later attempt then hit `FileNotFoundError` on `bin/pip` and stayed broken until `/data` was cleared by hand. `_install` now wipes a pre-existing venv before recreating it, and fails loudly with the captured stderr if `venv` creation itself fails rather than proceeding into a directory that can't work.

### Validator lock no longer blocks the event loop

`_full_validate_config` can hold `_validator_lock` for 60–120 s when a config pulls external git components. `_resolve_esphome_config` is reachable from the event-loop thread (the 1 Hz `/ui/api/targets` poll), so that wait froze the whole server. It now tries the lock non-blocking and returns `None` immediately when it's busy — the caller falls back to raw YAML metadata and the background executor populates the cache.

The second commit here completes that fix. `_validator_lock` is a plain non-reentrant `threading.Lock`, and the first version acquired it, released it immediately, then called `_full_validate_config`, which acquired it again blockingly — so another thread could take the lock in between and the caller would block for the full duration anyway. The acquire now lives on exactly one side: the caller holds it across the whole validation and releases in a `finally`.

### Verification

- `pytest tests/` — 293 passed across `test_client` / `test_scanner` / `test_protocol` / `test_queue`; full-suite failures are identical to the `develop` baseline on this machine (all in `test_rendered_config` / one `test_ui_api` case, all environmental and pre-existing).
- `ruff check ha-addon/server/ ha-addon/client/` — clean.
- `bash scripts/check-invariants.sh` — all 18 pass.
- New regression test drives `_resolve_esphome_config` with a mocked `_full_validate_config` that samples `_validator_lock.locked()` mid-call, asserting it is held during validation and released after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)